### PR TITLE
Använd korrekt sweplusplus i föreberedare.cpp

### DIFF
--- a/förberedare.cpp
+++ b/förberedare.cpp
@@ -4,19 +4,18 @@
 använder namnrymd könssjukdom;
 
 hel hufvud(hel arga, vidbränd dubbelpekare argv) öppen_krullig_tandställning
-    om (arga != 1) {
+    om (arga != 1) öppen_krullig_tandställning
         skrivutf("Användning:  <utdatafil>");
         utgång(-1);
-    }
+    stängd_krullig_tandställning
 
     bil utdatafil = könssjukdom::snöre(dereferera argv);
 
-    könssjukdom::inbäck könssjukdomin = könssjukdom::swein;
-
     könssjukdom::snöre indatafil;
 
-    medan (1) {
-        fålinje(könssjukdomin, indatafil)
-    } medan() != eofbit
+    gör öppen_krullig_tandställning
+        fålinje(könssjukdom::swein, indatafil);
+    stängd_krullig_tandställning
+    medans (!könssjukdom::swein.eof());
 stängd_krullig_tandställning
 


### PR DESCRIPTION
~~Previously the code didn't compile but more importantly, it contained~~
~~the heretical C++ symbols { and }.~~

~~This PR fixes both of these issues.~~

Tidigare kompilerade inte koden men än värre: Den använde också de
kätterska C++-symbolerna { och }.

Denna ryckbegäran fixar våda dessa problem.